### PR TITLE
Use Cats BitSet

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,8 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(
     name := s"${projectName}-core",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-core" % catsV
+      "org.typelevel" %%% "cats-collections-core" % "0.9.4",
+      "org.typelevel" %%% "cats-core"             % catsV
     ),
     libraryDependencies ++= {
       // Needed for macros

--- a/project/UTS46CodeGen.scala
+++ b/project/UTS46CodeGen.scala
@@ -713,12 +713,8 @@ object UTS46CodeGen {
          }"""
       }
 
-      // Create a val definition for one of the methods which returns a BitSet.
-      def bitSetMethod(name: String, rhs: Term): Defn.Val =
-        q"protected override final lazy val ${Pat.Var(Term.Name(name))} = $rhs"
-
-      // Create a val definition for one of the methods which returns an IntMap.
-      def intMapMethod(name: String, rhs: Term): Defn.Val =
+      // Create a val definition for one of the methods
+      def emitMethod(name: String, rhs: Term): Defn.Val =
         q"protected override final lazy val ${Pat.Var(Term.Name(name))} = $rhs"
 
       // For a set of code points which map to a single result code point,
@@ -747,43 +743,41 @@ object UTS46CodeGen {
       // Create the expressions for the various methods we are overriding.
 
       def validAlwaysMethod: Defn.Val =
-        bitSetMethod("validAlways", asBitSetTerm(validAlways))
+        emitMethod("validAlways", asBitSetTerm(validAlways))
 
       def validNV8Method: Defn.Val =
-        bitSetMethod("validNV8", asBitSetTerm(validNV8))
+        emitMethod("validNV8", asBitSetTerm(validNV8))
 
       def validXV8Method: Defn.Val =
-        bitSetMethod("validXV8", asBitSetTerm(validXV8))
+        emitMethod("validXV8", asBitSetTerm(validXV8))
 
       def ignoredMethod: Defn.Val =
-        bitSetMethod("ignored", asBitSetTerm(ignored))
+        emitMethod("ignored", asBitSetTerm(ignored))
 
       def disallowedMethod: Defn.Val =
-        bitSetMethod("disallowed", asBitSetTerm(disallowed))
+        emitMethod("disallowed", asBitSetTerm(disallowed))
 
       def deviationIgnoredMethod: Defn.Val =
-        bitSetMethod("deviationIgnored", asBitSetTerm(deviationIgnored))
+        emitMethod("deviationIgnored", asBitSetTerm(deviationIgnored))
 
       def disallowedSTD3ValidMethod: Defn.Val =
-        bitSetMethod("disallowedSTD3Valid", asBitSetTerm(disallowedSTD3Valid))
+        emitMethod("disallowedSTD3Valid", asBitSetTerm(disallowedSTD3Valid))
 
       def mappedMultiMethod: Defn.Val =
         // q"protected override final val mappedMultiCodePoints: IntMap[NonEmptyList[Int]] = ???"
-        intMapMethod("mappedMultiCodePoints", multiMappingToTrees(mappedMulti))
+        emitMethod("mappedMultiCodePoints", multiMappingToTrees(mappedMulti))
 
       def deviationMappedMethod: Defn.Val =
-        intMapMethod("deviationMapped", singleMappingToTrees(deviationMapped))
+        emitMethod("deviationMapped", singleMappingToTrees(deviationMapped))
 
       def deviationMultiMappedMethod: Defn.Val =
-        intMapMethod("deviationMultiMapped", multiMappingToTrees(deviationMultiMapped))
+        emitMethod("deviationMultiMapped", multiMappingToTrees(deviationMultiMapped))
 
       def disallowedSTD3MappedMethod: Defn.Val =
-        intMapMethod("disallowedSTD3Mapped", singleMappingToTrees(disallowedSTD3Mapped))
+        emitMethod("disallowedSTD3Mapped", singleMappingToTrees(disallowedSTD3Mapped))
 
       def disallowedSTD3MultiMappedMethod: Defn.Val =
-        intMapMethod(
-          "disallowedSTD3MultiMapped",
-          multiMappingToTrees(disallowedSTD3MultiMapped))
+        emitMethod("disallowedSTD3MultiMapped", multiMappingToTrees(disallowedSTD3MultiMapped))
 
       // Note: Things are different for the `def mapped: IntMap[Int]`
       // method. This is by far the largest method we will be generating. It

--- a/project/UTS46CodeGen.scala
+++ b/project/UTS46CodeGen.scala
@@ -678,9 +678,9 @@ object UTS46CodeGen {
         if (ranges.isEmpty && singles.isEmpty) {
           q"BitSet.empty"
         } else if (ranges.isEmpty) {
-          q"BitSet(..$singles)"
+          q"BitSet(..$singles).compact"
         } else {
-          q"List(..$ranges).foldLeft(BitSet(..$singles)){case (acc, value) => value.foldLeft(acc)(_ + _)}"
+          q"List(..$ranges).foldLeft(BitSet(..$singles)){case (acc, value) => value.foldLeft(acc)(_ + _)}.compact"
         }
       }
 


### PR DESCRIPTION
Especially on Scala 2.12.x, this is a game changer for startup time.

Also,

* Change the code point lookup from a switch of `mappedWithSentinels` to a set of `if/else` blocks, with successful high cardinality code paths prioritized over failure paths or low cardinality sets. * As a consequence of this change, the sentinel values are no longer used, so they were removed.
* Unroll relatively small code point ranges so we can put them into a giant `BitSet.apply` invocation. This is faster than lots of folding on `Range` values during initialization, but we can only do so much before we start bumping up against method size limits.
* Make the implementation of the `BitSet` and `IntMap` members `lazy`.